### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,12 +4,12 @@ project(ResectionPlanner)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "http://www.slicer.org/slicerWiki/index.php?title=Documentation/Nightly/Extensions/ResectionPlanner")
+set(EXTENSION_HOMEPAGE "https://www.slicer.org/wiki/Documentation/Nightly/Extensions/ResectionPlanner")
 set(EXTENSION_CATEGORY "IGT")
 set(EXTENSION_CONTRIBUTORS "Matt Lougheed (Queen's University)")
 set(EXTENSION_DESCRIPTION "Modules for surgical resection planning.")
-set(EXTENSION_ICONURL "http://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png")
-set(EXTENSION_SCREENSHOTURLS "http://www.slicer.org/slicerWiki/index.php/File:ResectionVolume_Screenshot.png")
+set(EXTENSION_ICONURL "https://wiki.slicer.org/slicerWiki/images/d/d6/ResectionPlannerLogo.png")
+set(EXTENSION_SCREENSHOTURLS "https://www.slicer.org/w/img_auth.php/8/82/ResectionVolume_Screenshot.png")
 
 set(EXTENSION_DEPENDS "SlicerRT") # Specified as a space separated string, a list or 'NA' if any
 


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.